### PR TITLE
Ensure that gltf-viewer always uses the GltfLoader

### DIFF
--- a/gltf/__init__.py
+++ b/gltf/__init__.py
@@ -26,6 +26,11 @@ def patch_loader(loader, gltf_settings=None):
                 else:
                     return _load_model(model_path, **kwargs)
         loader.load_model = loader.loadModel = types.MethodType(new_load_model, loader)
+    else:
+        # Ensure that our loader is the preferred choice for .gltf files.
+        type = registry.get_type_from_extension("gltf")
+        if not type or type.type.name != 'PythonLoaderFileType':
+            registry.register_type(GltfLoader)
 
 
 __all__ = [


### PR DESCRIPTION
When eg. running directly from the source code repository, using `python -m gltf.viewer` may not use the GltfLoader (but instead Assimp) since the entry points are not registered in that case.

This ensures that it will still work by having patch_loader explicitly register the loader extension if it hasn't already been registered.