### PR TITLE
Work around various tangent generation issues

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -994,6 +994,10 @@ class Converter():
         tana = [LVector3(0, 0, 0) for i in range(len(posdata))]
         tanb = [LVector3(0, 0, 0) for i in range(len(posdata))]
 
+        if not uvdata:
+            # No point generating tangents without UVs.
+            return
+
         # Gather tangent data from triangles
         for tri in tris:
             idx0, idx1, idx2 = tri
@@ -1002,15 +1006,14 @@ class Converter():
             duv1 = uvdata[idx1] - uvdata[idx0]
             duv2 = uvdata[idx2] - uvdata[idx0]
 
-            fconst = 1.0 / (duv1.x * duv2.y - duv2.x * duv1.y)
-            tangent = LVector3(*[
-                fconst * (duv2.y * edge1[i] - duv1.y * edge2[i])
-                for i in range(3)
-            ])
-            bitangent = LVector3(*[
-                fconst * (duv2.x * edge1[i] - duv1.x * edge2[i])
-                for i in range(3)
-            ])
+            denom = duv1.x * duv2.y - duv2.x * duv1.y
+            if denom != 0.0:
+                fconst = 1.0 / denom
+                tangent = (edge1.xyz * duv2.y - edge2.xyz * duv1.y) * fconst
+                bitangent = (edge1.xyz * duv2.x - edge2.xyz * duv1.x) * fconst
+            else:
+                tangent = LVector3(0)
+                bitangent = LVector3(0)
 
             for idx in tri:
                 tana[idx] += tangent


### PR DESCRIPTION
This fixes three issues that currently prevent loading many models:
* It tries to generate tangents even when the model contains no UVs, raising an exception.
* It doesn't handle degenerate cases, see #36.  The could should probably be changed to use a more robust algorithm, such as MikkTSpace.
* The code used list comprehensions, which are not only harder to read, but also 3x as slow as the equivalent vector math due to Python not being able to utilise SIMD operations.  This is demonstrated by the following code:
```python
import timeit


setup = """
from panda3d.core import LVector3
from random import random
fconst = 1
duv1 = LVector3(*(random() for i in range(3)))
duv2 = LVector3(*(random() for i in range(3)))
edge1 = LVector3(*(random() for i in range(3)))
edge2 = LVector3(*(random() for i in range(3)))
"""

print("Vector:", timeit.timeit("""
tangent = edge1 * duv2.y - edge2 * duv1.y
""", setup=setup))

print("Loop:", timeit.timeit("""
tangent = LVector3(*[
    fconst * (duv2.y * edge1[i] - duv1.y * edge2[i])
    for i in range(3)
])
""", setup=setup))
```
```
Vector: 0.5028925959995831
Loop: 1.6494933430003584
```