### PR TITLE
Fix issue loading rotations of Y-up models

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -325,12 +325,20 @@ class Converter():
                 gltf_mat = LMatrix4(*gltf_node.get('matrix'))
                 gltf_mat.transpose_in_place()
             else:
-                gltf_pos = LVector3(*gltf_node.get('translation', [0, 0, 0]))
-                gltf_rot = self.load_quaternion_as_hpr(gltf_node.get('rotation', [0, 0, 0, 1]))
-                gltf_scale = LVector3(*gltf_node.get('scale', [1, 1, 1]))
+                gltf_mat = LMatrix4(LMatrix4.ident_mat())
+                if 'scale' in gltf_node:
+                    gltf_mat.set_scale_mat(tuple(gltf_node['scale']))
 
-                gltf_mat = LMatrix4()
-                compose_matrix(gltf_mat, gltf_scale, gltf_rot, gltf_pos, self.compose_cs)
+                if 'rotation' in gltf_node:
+                    rot_mat = LMatrix4()
+                    rot = gltf_node['rotation']
+                    quat = LQuaternion(rot[3], rot[0], rot[1], rot[2])
+                    quat.extract_to_matrix(rot_mat)
+                    gltf_mat *= rot_mat
+
+                if 'translation' in gltf_node:
+                    gltf_mat *= LMatrix4.translate_mat(*gltf_node['translation'])
+
             if np.has_parent():
                 parent_mat = np.get_parent().get_mat()
             else:

--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -367,10 +367,6 @@ class Converter():
             lmat.set_row(i, LVecBase4(*mat[i * 4: i * 4 + 4]))
         return lmat
 
-    def load_quaternion_as_hpr(self, quaternion):
-        quat = LQuaternion(quaternion[3], quaternion[0], quaternion[1], quaternion[2])
-        return quat.get_hpr()
-
     def load_buffer(self, buffid, gltf_buffer):
         if 'uri' not in gltf_buffer:
             assert self.buffers[buffid]


### PR DESCRIPTION
For Y-up models, the rotation was not converted correctly because the quaternion was first converted to HPR in Z-up, and then composed into matrix form using the Y-up system.

Passing in `self.compose_cs` to the `get_hpr()` call would have been sufficient to fix this, but I reworked the math a bit to not rely on converting the quaternion to HPR only to then immediately convert it to a matrix.  This method is more direct and is theoretically less sensitive to numerical issues.

I do have other questions about the transformation loading code, such as why we are converting transforms to matrices rather than TransformState, and why we are multiplying with the inverse parent transform.  I think we need a set of unit test models that test a variety of transform composition situations so that we can verify that we are doing the right thing.  The sample models in the glTF sample repository don't appear to have complex transform graphs.

Fixes #34