### PR TITLE
Fix color of fallback normal map

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -417,7 +417,7 @@ class Converter():
 
         texture = Texture('normal-fallback')
         texture.setup_2d_texture(1, 1, Texture.T_unsigned_byte, Texture.F_rgb)
-        texture.set_clear_color(LColor(0, 0, 1, 1))
+        texture.set_clear_color(LColor(0.5, 0.5, 1, 1))
 
         self.textures['__normal-fallback'] = texture
 


### PR DESCRIPTION
As discussed here:
https://discourse.panda3d.org/t/colors-too-dark-after-gltf-export-from-blender-again/25477/12

The default value for the normal map should be `(0.5, 0.5, 1)` since that translates to a normal vector in the shader of `(0, 0, 1)`.  The current would translate to a normal value of `(-1, -1, 1)`, which results in the normalized vector of `(-0.57735, -0.57735, 0.57735)`.

I have not personally tested this.