### PR TITLE
Make texture stage order deterministic

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -579,6 +579,7 @@ class Converter():
                 continue
 
             texstage = TextureStage(str(i))
+            texstage.set_sort(i)
             texstage.set_texcoord_name(InternalName.get_texcoord_name(str(texinfo.get('texCoord', 0))))
             tex_attrib = tex_attrib.add_on_stage(texstage, texdata)
 


### PR DESCRIPTION
The sort parameter is not set for the texture stages, therefore the textures are randomly assigned to the texture slots, and so sometimes the model is rendered with the normal map or the roughness map as albedo map.

<img width="912" alt="correct display" src="https://user-images.githubusercontent.com/44778133/72211319-9456aa80-34c9-11ea-9cde-17ad88852fea.png">
<img width="912" alt="normalmap" src="https://user-images.githubusercontent.com/44778133/72211320-9456aa80-34c9-11ea-855d-cad3aad775db.png">
<img width="912" alt="metalnessmap" src="https://user-images.githubusercontent.com/44778133/72211321-94ef4100-34c9-11ea-90fc-5adcc01dbb98.png">
