### PR TITLE
Workaround for fallback textures

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -412,12 +412,14 @@ class Converter():
         texture = Texture('pbr-fallback')
         texture.setup_2d_texture(1, 1, Texture.T_unsigned_byte, Texture.F_rgba)
         texture.set_clear_color(LColor(1, 1, 1, 1))
+        texture.make_ram_image()
 
         self.textures['__pbr-fallback'] = texture
 
         texture = Texture('normal-fallback')
         texture.setup_2d_texture(1, 1, Texture.T_unsigned_byte, Texture.F_rgb)
         texture.set_clear_color(LColor(0.5, 0.5, 1, 1))
+        texture.make_ram_image()
 
         self.textures['__normal-fallback'] = texture
 


### PR DESCRIPTION
This is a workaround for https://github.com/Moguri/panda3d-gltf/issues/47 until https://github.com/panda3d/panda3d/issues/844 is fixed.