### PR TITLE
Support morph targets

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -195,7 +195,7 @@ indent-string='    '
 max-line-length=120
 
 # Maximum number of lines in a module
-max-module-lines=1500
+max-module-lines=2000
 
 # List of optional constructs for which whitespace checking is disabled. `dict-
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.

--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -158,7 +158,7 @@ class Converter():
         copy_lights = writing_bam and not hasattr(BamWriter, 'root_node')
 
         # Build scenegraphs
-        def add_node(root, gltf_scene, nodeid, jvtmap={}, cvsmap=[]):
+        def add_node(root, gltf_scene, nodeid, jvtmap, cvsmap):
             try:
                 gltf_node = gltf_data['nodes'][nodeid]
             except IndexError:
@@ -353,7 +353,7 @@ class Converter():
                 node_list += gltf_scene['extras']['hidden_nodes']
 
             for nodeid in node_list:
-                add_node(scene_root, gltf_scene, nodeid)
+                add_node(scene_root, gltf_scene, nodeid, {}, {})
 
             self.scenes[sceneid] = scene_root
 

--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -707,6 +707,16 @@ class Converter():
                 uvs = uv_data.get_data2f()
                 uv_data.set_data2f(uvs[0], 1 - uvs[1])
 
+        # Flip morph deltas from Y-up to Z-up.  This is apparently not done by
+        # transform_vertices(), below, so we do it ourselves.
+        if self.compose_cs == CS_yup_right:
+            for morph_i in range(reg_format.get_num_morphs()):
+                delta_data = GeomVertexRewriter(vdata, reg_format.get_morph_delta(morph_i))
+
+                while not delta_data.is_at_end():
+                    data = delta_data.get_data3f()
+                    delta_data.set_data3f(data[0], -data[2], data[1])
+
         # Repack mesh data
         vformat = GeomVertexFormat()
         varray_vert = GeomVertexArrayFormat()


### PR DESCRIPTION
I had to significantly overhaul the Character handling to make this work, since the previous code created a Character for every skin, which can't work for morphs since they are defined on the mesh level.  I think the new approach, to build a Character for every node that contains a skin or morphs, is more robust.

Needs testing.  I tested that CesiumMan still works, and that AnimatedMorphSphere and AnimatedMorphCube are morphing, but that's about it.

It actually supports morph names, which are exported by Blender into the `mesh.extras.targetNames` property.  Otherwise, it uses the names 0, 1, 2, etc.

Fixes #8

Note that (1) the *animation* of morph targets, and (2) default values for sliders will only work if Panda3D 1.10.6.dev6 or later is installed, which can be obtained from here:
https://buildbot.panda3d.org/downloads/8b6f82256e31e7840c60775c8f2f9e1084aae972/
Direct manipulation of morphs via controlJoint or freezeJoint is still possible in older versions.