### PR TITLE
Fix exception when texture cannot be found

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -407,6 +407,9 @@ class Converter():
         if self.settings.no_srgb:
             return
 
+        if texture is None:
+            return
+
         if texture.get_num_components() == 3:
             texture.set_format(Texture.F_srgb)
         elif texture.get_num_components() == 4:


### PR DESCRIPTION
This prevents the following exception from occurring when a texture is not found:
```
:gobj(error): Texture::read() - couldn't read: hair.png
:gobj(error): Unable to find texture "hair.png" on model-path /tmp:/home/rdb/Downloads:/home/rdb/Downloads:/home/rdb/.local/bin:/home/rdb/panda3d2/built/etc/..:/home/rdb/panda3d2/built/etc/../models
Traceback (most recent call last):
  File "/home/rdb/.local/lib/python3.8/site-packages/gltf/converter.py", line 1477, in load_model
    convert(file_path, bamfilepath, gltf_settings)
  File "/home/rdb/.local/lib/python3.8/site-packages/gltf/converter.py", line 1462, in convert
    converter.update(gltf_data, writing_bam=True)
  File "/home/rdb/.local/lib/python3.8/site-packages/gltf/converter.py", line 148, in update
    self.load_material(matid, gltf_mat)
  File "/home/rdb/.local/lib/python3.8/site-packages/gltf/converter.py", line 566, in load_material
    self.make_texture_srgb(self.textures[texinfos[-1]['index']])
  File "/home/rdb/.local/lib/python3.8/site-packages/gltf/converter.py", line 404, in make_texture_srgb
    if texture.get_num_components() == 3:
AttributeError: 'NoneType' object has no attribute 'get_num_components'
```