### PR TITLE
Fix crash when using Panda3D compiled with double floating point precision

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -916,7 +916,7 @@ class Converter():
                 tangent.z,
                 -1.0 if normal.cross(tan0).dot(tan1) < 0 else 1.0
             )
-            tangent_writer.set_data4f(tangent4)
+            tangent_writer.set_data4(tangent4)
 
         geom.set_vertex_data(gvd)
 


### PR DESCRIPTION
When loading a glTF file that requires tangent calculation, using a version of Panda3D compiled with double floating point precision, the converter crashes because we are using load_data4f() with a double precision vector.

<pre>
Traceback (most recent call last):
  File "third-party/gltf/gltf/loader.py", line 21, in load_file
    options=options
  File "third-party/gltf/gltf/converter.py", line 1325, in load_model
    convert(file_path, bamfilepath, gltf_settings)
  File "third-party/gltf/gltf/converter.py", line 1305, in convert
    converter.update(gltf_data, writing_bam=True)
  File "third-party/gltf/gltf/converter.py", line 152, in update
    self.load_mesh(meshid, gltf_mesh, gltf_data)
  File "third-party/gltf/gltf/converter.py", line 1060, in load_mesh
    self.load_primitive(node, gltf_primitive, gltf_data)
  File "third-party/gltf/gltf/converter.py", line 992, in load_primitive
    self.calculate_tangents(geom)
  File "third-party/gltf/gltf/converter.py", line 1047, in calculate_tangents
    tangent_writer.set_data4f(tangent4)
</pre>

This PR trivially fixes this :)
