### PR TITLE
Fix model and generated normals orientation

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -776,15 +776,21 @@ class Converter():
                 uvs = uv_data.get_data2f()
                 uv_data.set_data2f(uvs[0], 1 - uvs[1])
 
-        # Flip morph deltas from Y-up to Z-up.  This is apparently not done by
-        # transform_vertices(), below, so we do it ourselves.
         if self.compose_cs == CS_yup_right:
+            # Flip morph deltas from Y-up to Z-up.  This is apparently not done by
+            # transform_vertices(), below, so we do it ourselves.
             for morph_i in range(reg_format.get_num_morphs()):
                 delta_data = GeomVertexRewriter(vdata, reg_format.get_morph_delta(morph_i))
 
                 while not delta_data.is_at_end():
                     data = delta_data.get_data3f()
                     delta_data.set_data3f(data[0], -data[2], data[1])
+            # Flip tangents from Y-up to Z-up.
+            if 'TANGENT' in mesh_attribs:
+                tangent = GeomVertexRewriter(vdata, InternalName.make('tangent'))
+                while not tangent.is_at_end():
+                    data = tangent.get_data4f()
+                    tangent.set_data4f(data[0], -data[2], data[1], data[3])
 
         # Repack mesh data
         vformat = GeomVertexFormat()

--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -935,7 +935,10 @@ class Converter():
                 tangent.z,
                 -1.0 if normal.cross(tan0).dot(tan1) < 0 else 1.0
             )
-            tangent_writer.set_data4(tangent4)
+            if self.compose_cs == CS_yup_right:
+                tangent_writer.set_data4(tangent4[0], -tangent4[2], tangent4[1], tangent4[3])
+            else:
+                tangent_writer.set_data4(tangent4)
 
         geom.set_vertex_data(gvd)
 

--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -915,7 +915,7 @@ class Converter():
             if denom != 0.0:
                 fconst = 1.0 / denom
                 tangent = (edge1.xyz * duv2.y - edge2.xyz * duv1.y) * fconst
-                bitangent = (edge1.xyz * duv2.x - edge2.xyz * duv1.x) * fconst
+                bitangent = (edge2.xyz * duv1.x - edge1.xyz * duv2.x) * fconst
             else:
                 tangent = LVector3(0)
                 bitangent = LVector3(0)


### PR DESCRIPTION
This PR attempts to fix issues related to normals orientation described in #48. It contains three commits: 

The first commit converts model tangents from Y-up to Z-up coordinate system if the source is using Y-up CS.

The second commit converts generated tangents if the source model is using Y-up CS. As the vertex position is not converted by panda3d-gltf but by Panda3D itself when loading the converted model, the tangents are generated in the Y-up CS and so must be converted.

The third commit fix the sign of the generated bitangent vector, otherwise the generated normals looks wrong even when skipping axis conversion.

Invalid model normals :

<img width="912" alt="Invalid Model Normals" src="https://user-images.githubusercontent.com/44778133/84022458-95134000-a986-11ea-95fa-ba49fe6f7dec.png">

With this PR :

<img width="912" alt="Valid Model Normals" src="https://user-images.githubusercontent.com/44778133/84022502-aa886a00-a986-11ea-9781-04b77f0724c4.png">

Invalid generated normals :

<img width="912" alt="Invalid Generated Normals" src="https://user-images.githubusercontent.com/44778133/84022528-b4aa6880-a986-11ea-84ca-4a88dd4e79c5.png">

With this PR :

<img width="912" alt="Valid Generated Normals" src="https://user-images.githubusercontent.com/44778133/84022541-bd9b3a00-a986-11ea-8595-669f6a523813.png">
