### PR TITLE
Empty scene and component size fixes

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -241,11 +241,6 @@ class Converter():
                     if cvsmap:
                         self.combine_mesh_morphs(mesh, meshid, cvsmap)
 
-            if 'skin' in gltf_node and not 'mesh' in gltf_node:
-                print(
-                    "Warning: node {} has a skin but no mesh"
-                    .format(primitiveid)
-                )
             if 'camera' in gltf_node:
                 camid = gltf_node['camera']
                 cam = self.cameras[camid]

--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -55,6 +55,15 @@ class Converter():
         5125: GeomEnums.NT_uint32,
         5126: GeomEnums.NT_float32,
     }
+    _COMPONENT_SIZE_MAP = {
+        5120: 1,
+        5121: 1,
+        5122: 2,
+        5123: 2,
+        5124: 4,
+        5125: 4,
+        5126: 4,
+    }
     _COMPONENT_NUM_MAP = {
         'MAT4': 16,
         'VEC4': 4,
@@ -749,6 +758,7 @@ class Converter():
                     internal_name = InternalName.make(attrib_name)
                 num_components = self._COMPONENT_NUM_MAP[acc['type']]
                 numeric_type = self._COMPONENT_TYPE_MAP[acc['componentType']]
+                numeric_size = self._COMPONENT_SIZE_MAP[acc['componentType']]
                 content = self._ATTRIB_CONTENT_MAP.get(attrib_name, GeomEnums.C_other)
 
                 if '_target' in acc:
@@ -766,7 +776,7 @@ class Converter():
                         buffview['buffer'],
                         acc.get('byteOffset', 0) + buffview.get('byteOffset', 0),
                         acc['count'],
-                        buffview.get('byteStride', 4 * num_components)
+                        buffview.get('byteStride', numeric_size * num_components)
                     ))
 
             if is_interleaved:

--- a/gltf/viewer.py
+++ b/gltf/viewer.py
@@ -49,7 +49,10 @@ class App(ShowBase):
 
         bounds = self.model_root.getBounds()
         center = bounds.get_center()
-        radius = bounds.get_radius()
+        if bounds.is_empty():
+            radius = 1
+        else:
+            radius = bounds.get_radius()
 
         fov = self.camLens.get_fov()
         distance = radius / math.tan(math.radians(min(fov[0], fov[1]) / 2.0))


### PR DESCRIPTION
Empty scene means a scene, which does not have any visible geometry, like an armature without any meshes or armature with animation. So it shouldn't be complaining for missing meshes and doesn't crash gltf-viewer on empty bounds.

I don't know how does buffers are still working always assuming 4 as component size, but if you print vdata (which is GeomVertexData), you can see random transform_index values which is greater than number of bones. This is just confusing.
