### PR TITLE
Fix objects without emission texture being invisible with alpha on

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -466,8 +466,8 @@ class Converter():
         self.textures['__pbr-fallback'] = texture
 
         texture = Texture('emission-fallback')
-        texture.setup_2d_texture(1, 1, Texture.T_unsigned_byte, Texture.F_rgba)
-        texture.set_clear_color(LColor(0, 0, 0, 0))
+        texture.setup_2d_texture(1, 1, Texture.T_unsigned_byte, Texture.F_luminance)
+        texture.set_clear_color(LColor(0, 0, 0, 1))
 
         self.textures['__emission-fallback'] = texture
 


### PR DESCRIPTION
d7cd1b393d23d5b9876c9080ea71a9e15c89cadd introduced a regression: enabling transparency on an object without an emission texture would cause it to disappear when rendering without the simplepbr shader.  The reason is explained in #82.

The alpha channel of the clear color is ignored, but I set it to 1 anyway in case the format is ever changed to something with alpha.

Fixes #82