### PR TITLE
Use new Panda3D 1.10.8 M_emission mode

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -646,16 +646,9 @@ class Converter():
             texinfos[-1]['mode'] = TextureStage.M_normal
 
             # Emission map
-            factor = gltf_mat.get('emissiveFactor', [0.0, 0.0, 0.0])
-            pmat.set_emission(LColor(*factor, w=0.0))
-            if 'emissiveTexture' in gltf_mat:
-                texinfos.append(gltf_mat['emissiveTexture'])
-                texinfos[-1]['mode'] = TextureStage.M_add
-            else:
-                # The fallback texture is all-white, so set it to "modulate" to
-                # make sure the model isn't affected by it without simplepbr.
-                texinfos.append(emission_fallback)
-                texinfos[-1]['mode'] = TextureStage.M_modulate
+            pmat.set_emission(LColor(*gltf_mat.get('emissiveFactor', [0.0, 0.0, 0.0]), w=0.0))
+            texinfos.append(gltf_mat.get('emissiveTexture', emission_fallback))
+            texinfos[-1]['mode'] = TextureStage.M_emission
             if texinfos[-1]['index'] in self.textures:
                 self.make_texture_srgb(self.textures[texinfos[-1]['index']])
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=['gltf'],
     python_requires='>=3.6',
     install_requires=[
-        'panda3d',
+        'panda3d>=1.10.8',
         'panda3d-simplepbr>=0.6',
     ],
     setup_requires=[


### PR DESCRIPTION
Using M_add turns out to be a little awkward, because M_add doesn't multiply with the emission colour.  simplepbr needs the fallback texture to have (1, 1, 1, 1) colour, but that results in fully whiting out the model without simplepbr.

Therefore I added a new M_emission slot to 1.10.8, a specific slot that's disabled in the FFP (its specific behaviour can't be implemented easily using texture combiners, I'm afraid).  This makes use of that slot.

Thoughts on this approach?