### PR TITLE
Use correct array type for AnimChannelScalarTable.set_table()

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -1538,7 +1538,7 @@ class Converter():
                     # We have too many frames.
                     target_weights = target_weights[:num_frames]
 
-                group.set_table(CPTAFloat(target_weights))
+                group.set_table(CPTA_stdfloat(target_weights))
 
         gltf_node = gltf_data['nodes'][nodeid]
 


### PR DESCRIPTION
There was a remaining invalid casting to CPTAFloat which causes a crash on double precision builds of Panda3D

<pre>
Traceback (most recent call last):
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1822, in load_model
    convert(file_path, bamfilepath, gltf_settings)
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1793, in convert
    converter.update(gltf_data, writing_bam=True)
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 395, in update
    add_node(scene_root, gltf_scene, nodeid, {}, {})
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 229, in add_node
    self.build_character(panda_node, nodeid, jvtmap, cvsmap, gltf_data)
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1179, in build_character
    self.build_animation_morph(morph, nodeid, num_frames, gltf_anim,
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1569, in build_animation_morph
    self.build_animation_morph(parent, child, num_frames, gltf_anim, gltf_data)
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1569, in build_animation_morph
    self.build_animation_morph(parent, child, num_frames, gltf_anim, gltf_data)
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1569, in build_animation_morph
    self.build_animation_morph(parent, child, num_frames, gltf_anim, gltf_data)
  [Previous line repeated 6 more times]
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1565, in build_animation_morph
    create_channels(group, nodeid, target_names, weights)
  File "/home/ld/Projects/cosmonium/third-party/gltf/gltf/converter.py", line 1542, in create_channels
    group.set_table(CPTAFloat(target_weights))
TypeError: AnimChannelScalarTable.set_table() argument 1 must be ConstPointerToArray, not panda3d.core.ConstPointerToArray_float
</pre>

Note that the CPTAFloat in the following line must stay as the buffer always contains float32 data.

https://github.com/Moguri/panda3d-gltf/blob/3e6196fe791a2383f9c34fc59503564f2bd4a788/gltf/converter.py#L1516


