### PR TITLE
Don't share fallback textures info

### DIFF
--- a/gltf/converter.py
+++ b/gltf/converter.py
@@ -586,7 +586,8 @@ class Converter():
             self.mat_mesh_map[matid] = []
 
         pmat = Material(matname)
-        pbr_fallback = {'index': '__pbr-fallback', 'texCoord': 0}
+        base_color_fallback = {'index': '__pbr-fallback', 'texCoord': 0}
+        metallic_roughness_fallback = {'index': '__pbr-fallback', 'texCoord': 0}
         emission_fallback = {'index': '__emission-fallback', 'texCoord': 0}
         normal_fallback = {'index': '__normal-fallback', 'texCoord': 0}
         texinfos = []
@@ -596,7 +597,7 @@ class Converter():
                 pbrsettings = gltf_mat['pbrMetallicRoughness']
 
                 pmat.set_diffuse(LColor(*pbrsettings.get('baseColorFactor', [1.0, 1.0, 1.0, 1.0])))
-                texinfos.append(pbrsettings.get('baseColorTexture', pbr_fallback))
+                texinfos.append(pbrsettings.get('baseColorTexture', base_color_fallback))
                 if texinfos[-1]['index'] in self.textures:
                     self.make_texture_srgb(self.textures[texinfos[-1]['index']])
                 texinfos[-1]['mode'] = TextureStage.M_modulate
@@ -638,13 +639,13 @@ class Converter():
                 pbrsettings = gltf_mat['pbrMetallicRoughness']
 
                 pmat.set_base_color(LColor(*pbrsettings.get('baseColorFactor', [1.0, 1.0, 1.0, 1.0])))
-                texinfos.append(pbrsettings.get('baseColorTexture', pbr_fallback))
+                texinfos.append(pbrsettings.get('baseColorTexture', base_color_fallback))
                 if texinfos[-1]['index'] in self.textures:
                     self.make_texture_srgb(self.textures[texinfos[-1]['index']])
 
                 pmat.set_metallic(pbrsettings.get('metallicFactor', 1.0))
                 pmat.set_roughness(pbrsettings.get('roughnessFactor', 1.0))
-                texinfos.append(pbrsettings.get('metallicRoughnessTexture', pbr_fallback))
+                texinfos.append(pbrsettings.get('metallicRoughnessTexture', metallic_roughness_fallback))
                 texinfos[-1]['mode'] = TextureStage.M_selector
 
             # Normal map


### PR DESCRIPTION
When a mesh has no base color texture nor metallic roughness texture, but has a normal map or an emission map, the texture stage mode of the fallback base color texture is wrongly set to M_selector. This is due to the fact that the same fallback texture info record is used for both base color and metallic roughness. As the metallic roughness is configured after the base color, the texture stage mode of the fallback info record associated with the base color is overridden with the metallic roughness texture stage mode.

The following debug line in `load_material()`
```python
print("CREATE STAGE", i, texstage.get_mode(), texdata)
```

gives :

<pre>
CREATE STAGE 0 14 2d_texture pbr-fallback
  2-d, 1 x 1 pixels, each 4 bytes, srgb_alpha
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  4 bytes in ram, compression off

CREATE STAGE 1 14 2d_texture pbr-fallback
  2-d, 1 x 1 pixels, each 4 bytes, srgb_alpha
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  4 bytes in ram, compression off

CREATE STAGE 2 9 2d_texture foil_n.png
  2-d, 512 x 512 pixels, each 4 bytes, rgba
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  1048576 bytes in ram, compression off

CREATE STAGE 3 16 2d_texture emission-fallback
  2-d, 1 x 1 pixels, each 1 bytes, luminance
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  no ram image

TextureAttrib:on 0:pbr-fallback 1:pbr-fallback 2:foil_n.png 3:emission-fallback
</pre>

With this PR, the fallback info record are no longer shared and the texture stage mode is correct :

<pre>
CREATE STAGE 0 0 2d_texture pbr-fallback
  2-d, 1 x 1 pixels, each 4 bytes, srgb_alpha
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  4 bytes in ram, compression off

CREATE STAGE 1 14 2d_texture pbr-fallback
  2-d, 1 x 1 pixels, each 4 bytes, srgb_alpha
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  4 bytes in ram, compression off

CREATE STAGE 2 9 2d_texture foil_n.png
  2-d, 512 x 512 pixels, each 4 bytes, rgba
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  1048576 bytes in ram, compression off

CREATE STAGE 3 16 2d_texture emission-fallback
  2-d, 1 x 1 pixels, each 1 bytes, luminance
  sampler wrap(u=repeat, v=repeat, w=repeat, border=0 0 0 1) filter(min=default, mag=default, aniso=0) lod(min=-1000, max=1000, bias=0)  no ram image

TextureAttrib:on 0:pbr-fallback 1:pbr-fallback 2:foil_n.png 3:emission-fallback
</pre>
