### PR TITLE
Removing simplepbr dependency by default.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 ]
 dependencies = [
     "panda3d >= 1.10.8",
-    "panda3d-simplepbr >= 0.6",
 ]
 requires-python = ">= 3.8"
 


### PR DESCRIPTION
As per the discussion on Discord, there are three use cases where we wouldn't expect panda3d-gltf to depend on simplepbr:

- The user isn't expecting to use a separate rendering module
- The user is using custom shaders
- The user is using a separate rendering workflow or module

This is a one-line change which removes the dependency on panda3d-simplepbr by default. It appears that the only part of panda3d-gltf which relies on panda3d-simplepbr is the viewer.py which will prompt the user to install simplepbr if run.

I have tested that this successfully builds using build.