### PR TITLE
Accept absolute paths in gltf texture uris and avoid issues in 'copy' mode

### DIFF
--- a/gltf/_converter.py
+++ b/gltf/_converter.py
@@ -608,7 +608,10 @@ class Converter():
             else:
                 uri = urllib.parse.unquote(uri)
                 uri = Filename.from_os_specific(uri)
-                fulluri = Filename(self.filedir, uri)
+                if os.path.isabs(uri.toOsSpecific()):
+                    fulluri = uri
+                else:
+                    fulluri = Filename(self.filedir, uri)
                 texture = TexturePool.load_texture(fulluri, 0, False, LoaderOptions())
                 if not texture:
                     raise RuntimeError(f'failed to load texture: {fulluri}')

--- a/gltf/cli.py
+++ b/gltf/cli.py
@@ -141,8 +141,9 @@ def main():
             texdst = os.path.join(outdir.to_os_specific(), fname)
 
             texture.fullpath = fname
-            os.makedirs(os.path.dirname(texdst), exist_ok=True)
-            shutil.copy(texsrc, texdst)
+            if texsrc != texdst:
+                os.makedirs(os.path.dirname(texdst), exist_ok=True)
+                shutil.copy(texsrc, texdst)
 
     if args.animations == 'separate':
         for bundlenode in converter.active_scene.find_all_matches('**/+AnimBundleNode'):


### PR DESCRIPTION
This is proposed to fix #131 where a gltf using an absolute image path fails to locate because of an extra directory prefix.

Note that I can't seem to run the unit tests in my environment at the moment but I've checked this works at runtime during loadModel(), running manually at the command line and in bdist_apps.