### PR TITLE
converter: Avoid copying incomplete triangles

### DIFF
--- a/gltf/_converter.py
+++ b/gltf/_converter.py
@@ -1903,6 +1903,9 @@ class Converter():
 
                         vertices = prim_tmp.get_vertex_list()
                         for i in range(0, len(vertices), 3):
+                            if i+2 >= len(vertices):
+                                print(f'Less than 3 vertices remaining, skipping polygon.')
+                                continue
                             pos0 = vdata[vertices[i]].xyz
                             pos1 = vdata[vertices[i + 1]].xyz
                             pos2 = vdata[vertices[i + 2]].xyz


### PR DESCRIPTION
When converting collision meshes, degenerate triangles (i.e. single edges) would result in an indexing error in the line 

                            pos2 = vdata[vertices[i + 2]].xyz

This is because the line

                        for i in range(0, len(vertices), 3):
 
will enter the loop once (with i == 0) even if len(vertices) is 2. In this case, i+2 will try to read past the end of the vertices array.

This pull request catches this case and then skips the polygon with a warning.